### PR TITLE
Fix byte-compile warning about company-mode function

### DIFF
--- a/mtg-deck-mode.el
+++ b/mtg-deck-mode.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(declare-function company-doc-buffer "company")
+
 (defvar mtg-deck--font-lock-defaults
   '(
     ("^[[:blank:]]*SB:"


### PR DESCRIPTION
```
In end of data:
mtg-deck-mode.el:159:1:Warning: the function ‘company-doc-buffer’ is not known
    to be defined.
```
